### PR TITLE
Add conditional code for support form button

### DIFF
--- a/functions.php
+++ b/functions.php
@@ -18,6 +18,7 @@ require 'inc/after-single-posts.php';
 require 'inc/fellowship-post.php';
 require 'inc/publication-report.php';
 require 'inc/rss-newsletter.php';
+require 'inc/support-form.php';
 
 
 // Add theme support for gradients, and define them.

--- a/inc/support-form.php
+++ b/inc/support-form.php
@@ -1,0 +1,43 @@
+<?php
+/**
+ * Conditionally show the submit button
+ * https://wpforms.com/developers/how-to-conditionally-show-the-submit-button/
+ * 
+ * This functionality hides the submit button on the form when the user selects the "Enquire about training & commercial services" radio button.
+ * The purpose is to guide the user towards using the appropriate Commercial Services form instead, for these types of requests.
+ */
+  
+add_action( 'wp_head', function () { ?>
+   
+    <style>
+  
+    /* CSS hide submit button on page load */
+    #wpforms-form-2192 .wpforms-submit-container .wpforms-submit {
+            visibility:hidden;
+        }
+  
+    #wpforms-form-2192 .wpforms-submit-container .wpforms-submit.show-submit {
+            visibility:visible;
+        }
+   
+    </style>
+   
+<?php } );
+   
+   
+// Conditional logic for Submit button
+function wpf_dev_form_redirect() {
+    ?>
+    <script>
+        jQuery(function($){
+            $( "form#wpforms-form-2192" ).click(function(){
+                var selectedval = $( ".wpforms-form input[type='radio']:checked" ).val();
+                if(selectedval != "Enquire about training & commercial services"){
+                    $( ".wpforms-submit" ).addClass( "show-submit" );
+                }
+            });
+        });
+    </script>
+    <?php
+}
+add_action( 'wpforms_wp_footer_end', 'wpf_dev_form_redirect', 10 );


### PR DESCRIPTION
This PR hides the "submit" button on the support form when the user selects the "Enquire about training & commercial services" radio button.  The purpose is to guide the user towards using the appropriate Commercial Services form instead, for these types of requests.

Tutorial I followed to do this: https://wpforms.com/developers/how-to-conditionally-show-the-submit-button/

Conditions to hide other fields have been set through the WP Forms interface.