### PR TITLE
Ensure content is always returned from after single posts filter

### DIFF
--- a/inc/after-single-posts.php
+++ b/inc/after-single-posts.php
@@ -25,8 +25,9 @@ function gwf_after_post_main_content( $content ) {
             $content .= do_shortcode( "[sibwp_form id=2]" );
         endif;
 
-        return $content;
     endif;
+
+    return $content;
 }
 
 /**


### PR DESCRIPTION
This fixes the error we were seeing in the REST API, where post content and excerpts were not returned. The problem was that the "return" statement was inside the first "if" block, meaning that in every other context, no content at all was getting returned.

The content should be passed through in any case, but only when the "if" is true do we append the tags and the CO2.js message.